### PR TITLE
fix two warning: php7.1.5 nts make warning, gcc 4.8.5 20150623

### DIFF
--- a/beast.c
+++ b/beast.c
@@ -23,6 +23,7 @@
 #include "config.h"
 #endif
 
+#include <execinfo.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -1435,7 +1436,7 @@ PHP_FUNCTION(beast_file_expire)
     }
 
     if (expire > 0) {
-        string = php_format_date(format, strlen(format), expire, 1 TSRMLS_CC);
+        string = (char *)php_format_date(format, strlen(format), expire, 1 TSRMLS_CC);
         BEAST_RETURN_STRING(string, 0);
     } else {
         BEAST_RETURN_STRING("+Infinity", 1);


### PR DESCRIPTION
/root/softwares/php-beast/beast.c: In function 'segmentfault_deadlock_fix':
/root/softwares/php-beast/beast.c:1058:10: warning: assignment makes pointer from integer without a cast [enabled by default]
info = backtrace_symbols(array, (int)size);
^
/root/softwares/php-beast/beast.c: In function 'zif_beast_file_expire':
/root/softwares/php-beast/beast.c:1438:16: warning: assignment from incompatible pointer type [enabled by default]
string = php_format_date(format, strlen(format), expire, 1 TSRMLS_CC);
^

第一个告警是否要包含 #include <execinfo.h>？？？

第二个告警是否要强制转换？？？
string = (char *)php_format_date(format, strlen(format), expire, 1 TSRMLS_CC);

修改后php7.1.5 nts 和 php 5.4.16 nts不告警了