### PR TITLE
fix inline

### DIFF
--- a/beast_mm.c
+++ b/beast_mm.c
@@ -60,12 +60,12 @@ static int beast_mm_block_size = 0;
 static beast_atomic_t *mm_lock;
 extern int beast_pid;
 
-inline void beast_mm_lock()
+void beast_mm_lock()
 {
     beast_spinlock(mm_lock, beast_pid);
 }
 
-inline void beast_mm_unlock()
+void beast_mm_unlock()
 {
     beast_spinunlock(mm_lock, beast_pid);
 }

--- a/cache.c
+++ b/cache.c
@@ -36,12 +36,12 @@ static cache_item_t **beast_cache_buckets = NULL;
 static beast_atomic_t *cache_lock;
 extern int beast_pid;
 
-inline void beast_cache_lock()
+void beast_cache_lock()
 {
     beast_spinlock(cache_lock, beast_pid);
 }
 
-inline void beast_cache_unlock()
+void beast_cache_unlock()
 {
     beast_spinunlock(cache_lock, beast_pid);
 }


### PR DESCRIPTION
```
php-src-php-7.1.2/ext/php-beast/beast.c:1075
        free(info);
    41ea:       48 89 ef                mov    %rbp,%rdi
    41ed:       e8 4e f6 ff ff          callq  3840 <free@plt>
php-src-php-7.1.2/ext/php-beast/beast.c:1078
    beast_mm_unlock();     /* Maybe lock mm so free here */
    41f2:       31 c0                   xor    %eax,%eax
    41f4:       e8 07 f8 ff ff          callq  3a00 <beast_mm_unlock@plt>
php-src-php-7.1.2/ext/php-beast/beast.c:1079
    beast_cache_unlock();  /* Maybe lock cache so free here */
    41f9:       31 c0                   xor    %eax,%eax
    41fb:       e8 60 fc ff ff          callq  3e60 <beast_cache_unlock@plt>
php-src-php-7.1.2/ext/php-beast/beast.c:1081
    exit(sig);
    4200:       44 89 ef                mov    %r13d,%edi
    4203:       e8 88 fc ff ff          callq  3e90 <exit@plt>
    4208:       0f 1f 84 00 00 00 00    nopl   0x0(%rax,%rax,1)

```

反汇编可以看到inline根本没生效，windows下直接会编译出错。所以还不如直接去掉！
