### PR TITLE
spinlock.c 添加aarch64if分支，不然在aarch64上编译不过

### DIFF
--- a/spinlock.c
+++ b/spinlock.c
@@ -35,6 +35,8 @@
       __sync_bool_compare_and_swap(lock, o, n)
   #ifdef __arm__
     #define pause() __asm__("NOP");
+  #elif __aarch64__
+    #define pause() __asm__("NOP");
   #else
     #define pause() __asm__("pause")
   #endif


### PR DESCRIPTION
spinlock.c 添加aarch64if分支，不然在aarch64上编译不过