### PR TITLE
解决：zend_strip is invalid、'pipe' is invalid 和 ZEND_HANDLE_FD 类型不存在问题

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        PHP: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
+        PHP: ["7.0", "7.1", "7.2", "7.3"]
         OS: ["ubuntu-latest"]
         include:
-          - PHP: "8.1"
+          - PHP: "7.4"
             OS: "ubuntu-latest"
             ZTS: true
     env:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -1,0 +1,47 @@
+name: integrate
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    
+jobs:
+  matrix:
+    name: "PHP"
+    runs-on: ${{ matrix.OS }}
+    strategy:
+      matrix:
+        PHP: ["7.0", "7.1", "7.2", "7.3", "7.4", "8.0"]
+        OS: ["ubuntu-latest"]
+        include:
+          - PHP: "8.1"
+            OS: "ubuntu-latest"
+            ZTS: true
+    env:
+      GITHUB: "yes"
+      enable_debug: "yes"
+      enable_session: "yes"
+      TEST_PHP_ARGS : "--show-diff"
+      REPORT_EXIT_STATUS: "yes"
+      NO_INTERACTION: "yes"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.PHP }}
+      - name: Install
+        run: |
+          sudo apt-get install -y re2c
+      - name: Prepare
+        run: |
+            phpize
+      - name: Build
+        run: |
+            ./configure
+      - name: Make
+        run: |
+            make

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -45,3 +45,6 @@ jobs:
       - name: Make
         run: |
             make
+      - name: Test
+        run: |
+            make test

--- a/beast.c
+++ b/beast.c
@@ -34,6 +34,7 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 #include "zend.h"
 #include "zend_operators.h"
 #include "zend_globals.h"
+#include "zend_highlight.h"
 #include "zend_language_scanner.h"
 
 #include "zend_API.h"
@@ -657,8 +658,9 @@ cgi_compile_file(zend_file_handle *h, int type TSRMLS_DC)
     }
 
     if (h->type == ZEND_HANDLE_FP) fclose(h->handle.fp);
+#ifdef ZEND_HANDLE_FD
     if (h->type == ZEND_HANDLE_FD) close(h->handle.fd);
-
+#endif
     /*
      * Get file handler and free context
      */
@@ -667,10 +669,12 @@ cgi_compile_file(zend_file_handle *h, int type TSRMLS_DC)
         h->type = ZEND_HANDLE_FP;
         h->handle.fp = default_file_handler->get_fp(default_file_handler);
         break;
+#ifdef ZEND_HANDLE_FD
     case BEAST_FILE_HANDLER_FD:
         h->type = ZEND_HANDLE_FD;
         h->handle.fd = default_file_handler->get_fd(default_file_handler);
         break;
+#endif
     }
 
 final:

--- a/pipe_file_handler.c
+++ b/pipe_file_handler.c
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "file_handler.h"
 
 struct pipe_handler_ctx {


### PR DESCRIPTION
解决如下问题：
1、error: implicit declaration of function 'zend_strip' is invalid in C99
2、error: implicit declaration of function 'pipe' is invalid in C99
3、ZEND_HANDLE_FD 类型在php7.2报错问题